### PR TITLE
Add DEV_MODE configuration and update Telegram handler to respect it

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In the root directory, create a file named `.dev.vars` with the following struct
 
 ```
 TELEGRAM_BOT_TOKEN="YOUR_TELEGRAM_BOT_TOKEN_HERE"
+DEV_MODE=true
 ```
 
 **Important**: Replace `YOUR_TELEGRAM_BOT_TOKEN_HERE` with the actual token you receive from BotFather (see "Telegram Bot Setup" below). This file is ignored by Git, so your token will not be committed to the repository.

--- a/src/handlers/telegramHandler.ts
+++ b/src/handlers/telegramHandler.ts
@@ -31,7 +31,7 @@ export async function handleTelegramWebhook(
     const message = update.message;
 
     // Only count/process messages from supergroups (avoid DMs)
-    if (message.chat.type !== 'supergroup') {
+    if (message.chat.type !== 'supergroup' && !c.env.DEV_MODE) {
       console.log(`[${timestamp}] Ignoring message from non-supergroup chat: ${message.chat.type}`);
       return c.json({
         success: true,

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -7,6 +7,7 @@ declare namespace Cloudflare {
 		DB: D1Database;
 		AI: Ai;
 		ASSETS: Fetcher;
+        DEV_MODE?: boolean | string
 	}
 }
 interface CloudflareBindings extends Cloudflare.Env {}


### PR DESCRIPTION
**Fix: Add DEV_MODE flag to bypass non-supergroup block in local dev**

Update `telegramHandler.ts` to allow private and group messages during local testing by checking `c.env.DEV_MODE`. Set `DEV_MODE=true` in `.dev.vars` to enable full command testing outside supergroups.
Issue (https://github.com/KhmerCoders/khmercoders-bot/commit/552b55e8cb65b5afc0cc1bc53faad9458646b375#diff-160ec0c93e96bf08b6fdac5db00f32cb616112a14b1dc76b3caecfc3db953626R38:~:text=//%20Only%20count/process,49)